### PR TITLE
Handles STOPPED containers

### DIFF
--- a/ecs_container_exporter/cpu_metrics.py
+++ b/ecs_container_exporter/cpu_metrics.py
@@ -44,6 +44,9 @@ def calculate_cpu_metrics(stats, task_cpu_limit, task_container_limits,
 
     online_cpus = get_online_cpus(stats)
     for container_id, container_stats in stats.items():
+        # container_stats is None when containers are in a STOPPED state
+        if container_stats is None:
+            continue
         metrics = []
         tags = task_container_tags[container_id]
 
@@ -240,4 +243,7 @@ def get_online_cpus(stats):
 
     """
     for container_id, container_stats in stats.items():
+        # container_stats is None when containers are in a STOPPED state
+        if container_stats is None:
+            continue
         return container_stats['cpu_stats']['online_cpus']

--- a/ecs_container_exporter/io_metrics.py
+++ b/ecs_container_exporter/io_metrics.py
@@ -88,6 +88,9 @@ def calculate_io_metrics(stats, task_container_tags):
     # if this changes, the task metrics logic will change below
     metric_type = 'counter'
     for container_id, container_stats in stats.items():
+        # container_stats is None when containers are in a STOPPED state
+        if container_stats is None:
+            continue
         metrics = []
         blkio_stats = container_stats.get('blkio_stats')
 

--- a/ecs_container_exporter/memory_metrics.py
+++ b/ecs_container_exporter/memory_metrics.py
@@ -13,6 +13,9 @@ def calculate_memory_metrics(stats, task_container_tags):
     task_metrics = defaultdict(int)
     metric_type = 'gauge'
     for container_id, container_stats in stats.items():
+        # container_stats is None when containers are in a STOPPED state
+        if container_stats is None:
+            continue
         metrics = []
         tags = task_container_tags[container_id]
         memory_stats = container_stats.get('memory_stats', {})

--- a/ecs_container_exporter/network_metrics.py
+++ b/ecs_container_exporter/network_metrics.py
@@ -27,6 +27,9 @@ def calculate_network_metrics(stats, task_container_tags):
     # if this changes, the task metrics logic will change below
     metric_type = 'counter'
     for container_id, container_stats in stats.items():
+        # container_stats is None when containers are in a STOPPED state
+        if container_stats is None:
+            continue
         metrics = []
         tags = task_container_tags[container_id]
         network_stats = container_stats.get('networks')


### PR DESCRIPTION
When containers are in a STOPPED state, they will return `None` for
their `container_stats` value from the task stats metadata endpoint.

Instead of raising an exception, we skip STOPPED containers while
parsing metrics